### PR TITLE
Standardize project gallery display across all projects

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -7,11 +7,11 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <meta name="cache-bust" content="20251013T1119">
+    <meta name="cache-bust" content="20251021T1700">
     <title>Projets - Hamza Elyoubi</title>
     <link rel="icon" href="data:;base64,iVBORw0KGgo="> <!-- Empty favicon -->
-    <link rel="stylesheet" href="styles/main.css?v=20251013T1119">
-    <link rel="stylesheet" href="styles/themes.css?v=20251013T1119">
+    <link rel="stylesheet" href="styles/main.css?v=20251021T1700">
+    <link rel="stylesheet" href="styles/themes.css?v=20251021T1700">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <meta name="description" content="Projets et réalisations de Hamza Elyoubi">
     <meta name="keywords" content="Hamza Elyoubi, Projets, Développement, Portfolio, Réalisations">
@@ -222,15 +222,15 @@
             iframe.contentWindow.Promise = Promise;
         });
     </script>
-    <script type="module" src="scripts/main.js?v=20251013T1119"></script>
+    <script type="module" src="scripts/main.js?v=20251021T1700"></script>
     <script type="module">
-        import { loadProjectsPage } from './scripts/pageLoader.js?v=20251013T1119';
+        import { loadProjectsPage } from './scripts/pageLoader.js?v=20251021T1700';
 
         document.addEventListener('DOMContentLoaded', () => {
             loadProjectsPage();
         });
     </script>
-    <script type="module" src="scripts/formHandler.js?v=20251013T1119"></script>
+    <script type="module" src="scripts/formHandler.js?v=20251021T1700"></script>
 </body>
 
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1122,15 +1122,17 @@ button[id*="close"],
     scroll-snap-align: start;
     border-radius: 8px;
     overflow: hidden;
+    aspect-ratio: 3/2;
+    background-color: var(--card-bg);
 }
 
 .modal-project-gallery .gallery-image {
     width: 100%;
-    height: 200px;
-    object-fit: contain;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
     transition: transform 0.3s ease;
     cursor: pointer;
-    background-color: var(--card-bg);
 }
 
 .modal-project-gallery .gallery-image:hover {
@@ -1375,10 +1377,14 @@ body {
 
     .modal-project-gallery .gallery-item {
         flex: 0 0 250px;
+        aspect-ratio: 3/2;
     }
 
     .modal-project-gallery .gallery-image {
-        height: 150px;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
     }
 
     .project-link-btn {


### PR DESCRIPTION
Changes:
- Update gallery CSS to use consistent aspect ratio (3:2) for all images
- Change object-fit from 'contain' to 'cover' for uniform appearance
- Apply consistent styling for both desktop and mobile views
- Update cache-busting version to 20251021T1700

This ensures all project galleries display images at the same size regardless of their original aspect ratios, providing a more professional and consistent user experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)