### PR TITLE
Polish portfolio content: grammar, terminology, and date formatting

### DIFF
--- a/data/portfolioData.json
+++ b/data/portfolioData.json
@@ -10,7 +10,7 @@
         },
         "location": "Nantes, France",
         "bio": {
-            "en": "Senior Java Software Engineer & Tech Lead with 8+ years of experience, I specialize in backend architecture, Spring Boot ecosystems, and technical leadership. I drive technical design, coordination, and quality across complex projects while promoting GenAI adoption to enhance team productivity and software quality.",
+            "en": "Senior Java Software Engineer & Tech Lead with 8+ years of experience, I specialize in backend architecture, the Spring Boot ecosystem, and technical leadership. I drive technical design, coordination, and quality across complex projects while promoting GenAI adoption to enhance team productivity and software quality.",
             "fr": "Ingénieur Logiciel Senior Java & Tech Lead avec plus de 8 ans d'expérience, je maîtrise l'architecture backend, l'écosystème Spring Boot et le leadership technique. J'assure la conception, la coordination et la qualité technique sur des projets complexes tout en promouvant l'adoption du GenAI pour améliorer la productivité et la qualité logicielle."
         },
         "resume": "assets/resumes/2026-02-26 HE - Main Version - VALIDATED.pdf",
@@ -43,7 +43,7 @@
                 "position": "Tech Lead Java",
                 "duration": "May 2026 - Present",
                 "achievements": [
-                    "- Technical reference for MASA SINEMA large-scale animal traceability modernization program",
+                    "- Technical lead for the MASA SINEMA large-scale animal traceability modernization program",
                     "- Led transition to event-driven architecture to improve system scalability and resilience",
                     "- Code reviews, technical specifications writing, and CI/CD supervision (Jenkins, SonarQube)",
                     "- Conducted GitHub Copilot training and adoption sessions with development teams",
@@ -66,9 +66,9 @@
                 "position": "Tech Lead Java / Software Engineer",
                 "duration": "January 2022 - July 2025",
                 "achievements": [
-                    "- Technical leadership contributing to evolution and modernization of mission-critical high-volume applications",
+                    "- Technical leadership contributing to the evolution and modernization of mission-critical high-volume applications",
                     "- Team coaching and mentoring of 5 junior developers as technical tutor",
-                    "- GenAI reference on the department, responsible for adoption of development assistance tools (GitHub Copilot, Codestral)",
+                    "- GenAI champion for the department, responsible for adoption of development assistance tools (GitHub Copilot, Codestral)",
                     "- Code reviews, technical specifications, and CI/CD pipeline supervision",
                     "- Stack: Java 8, Hibernate, HTML/JS, Jenkins, Oracle, GIS"
                 ]
@@ -141,9 +141,9 @@
                 "position": "Tech Lead Java / Ingénieur Logiciels",
                 "duration": "Janvier 2022 - Juillet 2025",
                 "achievements": [
-                    "- Contribution à l'évolution et à la modernisation d'applications critiques à forte volumétrie dans un environnement à forte contrainte métier",
+                    "- Contribution à l'évolution et à la modernisation d'applications critiques à forte volumétrie dans un environnement à fortes contraintes métier",
                     "- Accompagnement et montée en compétences des développeurs de l'équipe et mentorat de 5 développeurs juniors en tant que tuteur",
-                    "- Référent GenAI sur le pôle, responsable de l'adoption des outils d'assistance au développement (GitHub Copilot, Codestral)",
+                    "- Référent GenAI du pôle, responsable de l'adoption des outils d'assistance au développement (GitHub Copilot, Codestral)",
                     "- Réalisation de revues de code, rédaction des spécifications techniques et supervision des pipelines CI/CD",
                     "- Stack : Java 8, Hibernate, HTML/JS, Jenkins, Oracle, SIG"
                 ]
@@ -201,7 +201,7 @@
             {
                 "institution": "L'institut spécialisé de technologie appliquée NTIC",
                 "degrees": [
-                    "OffShoring Training, Java EE Designer",
+                    "Offshoring Training, Java EE Designer",
                     "2012 - 2013"
                 ]
             },
@@ -288,7 +288,7 @@
             {
                 "institution": "Faculté des sciences et techniques Settat",
                 "degrees": [
-                    "Licence universitaire professionnel en Base de données et technologie web",
+                    "Licence universitaire professionnelle en Base de données et technologie web",
                     "2015 - 2016"
                 ]
             }
@@ -469,56 +469,56 @@
             {
                 "institution": "Pluralsight",
                 "title": "Unit Testing Fundamentals",
-                "date": "1 Août, 2024",
+                "date": "Août 01, 2024",
                 "badgeUrl": "https://app.pluralsight.com/achievements/share/6d88a39e-57a8-41a6-8928-4c97138f9e06",
                 "badgeImg": "assets/e-learning/pluralsight/pluralsight.png"
             },
             {
                 "institution": "Pluralsight",
                 "title": "Application Analysis with SonarQube",
-                "date": "14 Juillet, 2024",
+                "date": "Juillet 14, 2024",
                 "badgeUrl": "https://app.pluralsight.com/achievements/share/f168345b-5160-44ef-8b83-25b736978bff",
                 "badgeImg": "assets/e-learning/pluralsight/pluralsight.png"
             },
             {
                 "institution": "Pluralsight",
                 "title": "Code Review: Best Practices",
-                "date": "14 Juillet, 2024",
+                "date": "Juillet 14, 2024",
                 "badgeUrl": "https://app.pluralsight.com/achievements/share/d5eaea7b-911b-4d1f-b6e7-32f7d0c099a8",
                 "badgeImg": "assets/e-learning/pluralsight/pluralsight.png"
             },
             {
                 "institution": "Pluralsight",
                 "title": "Git: The Big Picture",
-                "date": "12 Juillet, 2024",
+                "date": "Juillet 12, 2024",
                 "badgeUrl": "https://app.pluralsight.com/achievements/share/e2c9bc99-06d9-4cd6-bac9-058a89d46016",
                 "badgeImg": "assets/e-learning/pluralsight/pluralsight.png"
             },
             {
                 "institution": "Pluralsight",
                 "title": "Java: Writing Readable and Maintainable Code",
-                "date": "11 Juillet, 2024",
+                "date": "Juillet 11, 2024",
                 "badgeUrl": "https://app.pluralsight.com/achievements/share/d1d087a3-a59a-4b60-a06c-fe0fcb42f32a",
                 "badgeImg": "assets/e-learning/pluralsight/pluralsight.png"
             },
             {
                 "institution": "Pluralsight",
                 "title": "GitHub Copilot Fundamentals: AI Paired Programming",
-                "date": "4 Juin, 2024",
+                "date": "Juin 04, 2024",
                 "badgeUrl": "https://app.pluralsight.com/achievements/share/94db2707-2081-4499-ab29-4f06a42912b2",
                 "badgeImg": "assets/e-learning/pluralsight/pluralsight.png"
             },
             {
                 "institution": "Pluralsight",
                 "title": "Modern Java: The Big Picture",
-                "date": "15 Mars, 2021",
+                "date": "Mars 15, 2021",
                 "badgeUrl": "https://app.pluralsight.com/achievements/share/46ded322-d99d-4d53-8f23-305a3f173495",
                 "badgeImg": "assets/e-learning/pluralsight/pluralsight.png"
             },
             {
                 "institution": "LinkedIn Learning",
                 "title": "Découvrir l'IA générative",
-                "date": "Avr. 29, 2024",
+                "date": "Avril 29, 2024",
                 "badgeUrl": "assets/e-learning/linkdin/CertificatDaccomplissement_Decouvrir lIA generative.pdf",
                 "badgeImg": "assets/e-learning/linkdin/linkdinLogo.png"
             },
@@ -660,7 +660,7 @@
         "fr": [
             "Scrum Master Certifié PSM1",
             "Dirigé la migration de 3 systèmes hérités majeurs vers des architectures modernes",
-            "Mentoré plus de 15 développeurs juniors vers des rôles seniors",
+            "Mentoré plus de 15 développeurs juniors dans leur progression vers des postes seniors",
             "Mise en place de pipelines CI/CD réduisant le temps de déploiement de 40%"
         ]
     },
@@ -781,15 +781,15 @@
             "sections": [
                 {
                     "heading": "My Tech Watch",
-                    "content": "As a Senior Software Engineer & Tech Lead passionate about the fast evolution of digital technologies and generative AI, I dedicate time every day to tech watch. It helps me stay up to date, understand market trends and anticipate changes in our profession.\n\nI read high-tech and developer news via RSS (aggregated with Feedly), follow trainings on Pluralsight and watch technical content on YouTube."
+                    "content": "As a Senior Software Engineer & Tech Lead passionate about the fast evolution of digital technologies and generative AI, I dedicate time every day to tech watch. It helps me stay up to date, understand market trends and anticipate changes in our profession.\n\nI read high-tech and developer news via RSS (aggregated with Feedly), take courses on Pluralsight and watch technical content on YouTube."
                 },
                 {
                     "heading": "Watch Tools",
-                    "content": "Feedly is the core of my daily monitoring. I aggregate primary sources around software development, AI, cloud, and development best practices.\n\nI follow publications such as TechCrunch, The Verge, Medium (AI & Software Engineering), Dev.to and InfoQ.\n\nI also use YouTube to complement my watch with more practical video formats and follow channels like Fireship, Traversy Media, Micode, Unchained AI and Matt Wolfe for GenAI and modern frameworks."
+                    "content": "Feedly is the core of my daily monitoring. I aggregate primary sources around software development, AI, cloud, and best practices.\n\nI follow publications such as TechCrunch, The Verge, Medium (AI & Software Engineering), Dev.to and InfoQ.\n\nI also use YouTube to complement my watch with more practical video formats and follow channels like Fireship, Traversy Media, Micode, Unchained AI and Matt Wolfe for GenAI and modern frameworks."
                 },
                 {
                     "heading": "Main Themes",
-                    "content": "Topics I monitor depending on missions and interests:\n\n- Generative AI & LLMs: continuously testing tools like Claude Code, GitHub Copilot, Mistral AI or Gemini CLI to understand strengths and limits.\n- Software architecture & best practices: code quality, CI/CD pipelines, automated testing, scalability.\n- Cloud trends & DevOps: evolutions in AWS, Azure, CI tools like Jenkins and SonarQube.\n- High-tech news: broader innovations beyond development."
+                    "content": "Topics I monitor depending on missions and interests:\n\n- Generative AI & LLMs: continuously testing tools like Claude Code, GitHub Copilot, Mistral AI or Gemini CLI to understand their strengths and limitations.\n- Software architecture & best practices: code quality, CI/CD pipelines, automated testing, scalability.\n- Cloud trends & DevOps: developments in AWS, Azure, and CI tools like Jenkins and SonarQube.\n- High-tech news: broader innovations beyond development."
                 },
                 {
                     "heading": "Organization",


### PR DESCRIPTION
## Summary
This PR contains a comprehensive review and refinement of portfolio content across both English and French sections, focusing on grammar corrections, improved terminology, and standardized date formatting for consistency.

## Key Changes

**Grammar & Wording Improvements:**
- Fixed "Spring Boot ecosystems" → "the Spring Boot ecosystem" (bio section)
- Changed "Technical reference" → "Technical lead" (MASA SINEMA achievement)
- Added missing articles: "evolution" → "the evolution" and "GenAI reference" → "GenAI champion"
- Improved French grammar: "à forte contrainte métier" → "à fortes contraintes métier"
- Fixed capitalization: "OffShoring" → "Offshoring"
- Corrected French degree title: "professionnel" → "professionnelle"

**Terminology Refinements:**
- "follow trainings" → "take courses" (more natural English phrasing)
- "development best practices" → "best practices" (removed redundancy)
- "strengths and limits" → "strengths and limitations" (more formal)
- "evolutions in AWS, Azure" → "developments in AWS, Azure" (consistency)
- "Mentoré plus de 15 développeurs juniors vers des rôles seniors" → "Mentoré plus de 15 développeurs juniors dans leur progression vers des postes seniors" (improved clarity)

**Date Formatting Standardization:**
- Converted all French date formats from "DD Mois, YYYY" to "Mois DD, YYYY" pattern for consistency
- Examples: "1 Août, 2024" → "Août 01, 2024", "14 Juillet, 2024" → "Juillet 14, 2024"
- Standardized abbreviation: "Avr." → "Avril"
- Aligns with the data structure convention for language-appropriate date formatting

## Implementation Details
All changes are content-only modifications to `data/portfolioData.json`. No functional code changes were made. The updates maintain the existing data structure while improving readability, professionalism, and consistency across the portfolio's multilingual content.

https://claude.ai/code/session_01ENs3J8TCo1P6b6LKpx5jE5